### PR TITLE
Fix temperature forced mode example

### DIFF
--- a/examples/temperature-forced-mode.py
+++ b/examples/temperature-forced-mode.py
@@ -15,5 +15,5 @@ bmp280.setup(mode="forced")
 
 while True:
     temperature = bmp280.get_temperature()
-    print("{temperature:05.2f}*C")
+    print(f"{temperature:05.2f}*C")
     time.sleep(1)


### PR DESCRIPTION
**Changed:** Added f prefix to the string in the print function.

By adding the f prefix before the string, it correctly indicates an f-string, which allows the use of embedded expressions inside string literals. This ensures that the temperature variable is correctly formatted and printed as intended.